### PR TITLE
Add mono fonts also well as some references

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Running `$ npm start` will process the source CSS and place the built CSS in the
                'franklin gothic medium', 'century gothic', /* Windows stuff */
                'Liberation Sans', /* Linux */
                sans-serif; /* Everything else */ }
+.system-mono { font-family: Menlo, Monaco, /* MacOS */
+              'Segoe UI Mono, Lucida Console', /* Windows */
+              'Fira Mono', /* Firefox OS */
+              'Roboto Mono', 'Noto Mono', /* Google stuff */
+              'Droid Sans Mono', /* Old Google stuff */
+              'Ubuntu Mono', 'DejaVu Sans Mono', 'Liberation Mono', /* Linux */
+              'Courier New', /* MacOS and Windows */
+              monospace; /* Everything else */ }
 /*
   References:
 
@@ -86,6 +94,9 @@ Running `$ npm start` will process the source CSS and place the built CSS in the
   https://en.wikipedia.org/wiki/Avenir_(typeface)
   https://www.google.com/design/spec/style/typography.html#typography-typeface
   https://core.trac.wordpress.org/ticket/36753#comment:85
+  http://font.ubuntu.com/
+  https://mozilla.github.io/Fira/
+  https://fedorahosted.org/liberation-fonts/
 
 */
 ```

--- a/css/system-fonts.css
+++ b/css/system-fonts.css
@@ -15,6 +15,14 @@
                'franklin gothic medium', 'century gothic', /* Windows stuff */
                'Liberation Sans', /* Linux */
                sans-serif; /* Everything else */ }
+.system-mono { font-family: Menlo, Monaco, /* MacOS */
+              'Segoe UI Mono, Lucida Console', /* Windows */
+              'Fira Mono', /* Firefox OS */
+              'Roboto Mono', 'Noto Mono', /* Google stuff */
+              'Droid Sans Mono', /* Old Google stuff */
+              'Ubuntu Mono', 'DejaVu Sans Mono', 'Liberation Mono', /* Linux */
+              'Courier New', /* MacOS and Windows */
+              monospace; /* Everything else */ }
 /*
   References:
 
@@ -22,6 +30,9 @@
   https://en.wikipedia.org/wiki/Avenir_(typeface)
   https://www.google.com/design/spec/style/typography.html#typography-typeface
   https://core.trac.wordpress.org/ticket/36753#comment:85
+  http://font.ubuntu.com/
+  https://mozilla.github.io/Fira/
+  https://fedorahosted.org/liberation-fonts/
 
 */
 

--- a/css/system-fonts.min.css
+++ b/css/system-fonts.min.css
@@ -1,2 +1,2 @@
-.system-sans-serif{font-family:-apple-system,BlinkMacSystemFont,avenir next,avenir,Segoe UI,lucida grande,helvetica neue,helvetica,Fira Sans,roboto,noto,Droid Sans,cantarell,oxygen,ubuntu,franklin gothic medium,century gothic,Liberation Sans,sans-serif}
+.system-sans-serif{font-family:-apple-system,BlinkMacSystemFont,avenir next,avenir,Segoe UI,lucida grande,helvetica neue,helvetica,Fira Sans,roboto,noto,Droid Sans,cantarell,oxygen,ubuntu,franklin gothic medium,century gothic,Liberation Sans,sans-serif}.system-mono{font-family:Menlo,Monaco,Segoe UI Mono\, Lucida Console,Fira Mono,Roboto Mono,Noto Mono,Droid Sans Mono,Ubuntu Mono,DejaVu Sans Mono,Liberation Mono,Courier New,monospace}
 

--- a/src/system-fonts.css
+++ b/src/system-fonts.css
@@ -37,5 +37,8 @@
   https://en.wikipedia.org/wiki/Avenir_(typeface)
   https://www.google.com/design/spec/style/typography.html#typography-typeface
   https://core.trac.wordpress.org/ticket/36753#comment:85
+  http://font.ubuntu.com/
+  https://mozilla.github.io/Fira/
+  https://fedorahosted.org/liberation-fonts/
 
 */

--- a/src/system-fonts.css
+++ b/src/system-fonts.css
@@ -19,6 +19,16 @@
                sans-serif; /* Everything else */
 }
 
+.system-mono { 
+  font-family: Menlo, Monaco, /* MacOS */
+              'Segoe UI Mono, Lucida Console', /* Windows */
+              'Fira Mono', /* Firefox OS */
+              'Roboto Mono', 'Noto Mono', /* Google stuff */
+              'Droid Sans Mono', /* Old Google stuff */
+              'Ubuntu Mono', 'DejaVu Sans Mono', 'Liberation Mono', /* Linux */
+              'Courier New', /* MacOS and Windows */
+              monospace; /* Everything else */
+}
 
 /*
   References:


### PR DESCRIPTION
Hi,

In most of my projects, I find myself having to go check one of your website in order to steal _that_ font-family declaration:

``` css
font-family: -apple-system, BlinkMacSystemFont, avenir next, avenir, ubuntu, roboto, noto, segoe ui, helvetica, helvetica neue, arial, sans-serif;
```

 And so, I really love the idea of this tiny lib. No more copy-pasting.

But since I also use monospace fonts, I thought it would be great to add them to this lib. Let me know what you think. :wink:

Max
